### PR TITLE
Add ability to start mongo single replica set

### DIFF
--- a/src/TestEnvironment.Docker.Containers.Mongo/DockerEnvironmentBuilderExtensions.cs
+++ b/src/TestEnvironment.Docker.Containers.Mongo/DockerEnvironmentBuilderExtensions.cs
@@ -10,6 +10,7 @@ namespace TestEnvironment.Docker.Containers.Mongo
             string replicaSetName = "rs0",
             string imageName = "mongo",
             string tag = "latest",
+            ushort? port = null,
             IDictionary<string, string> environmentVariables = null,
             bool reuseContainer = false)
         {
@@ -20,6 +21,7 @@ namespace TestEnvironment.Docker.Containers.Mongo
                     replicaSetName,
                     imageName,
                     tag,
+                    port,
                     environmentVariables,
                     builder.IsDockerInDocker,
                     reuseContainer,

--- a/src/TestEnvironment.Docker.Containers.Mongo/DockerEnvironmentBuilderExtensions.cs
+++ b/src/TestEnvironment.Docker.Containers.Mongo/DockerEnvironmentBuilderExtensions.cs
@@ -7,6 +7,7 @@ namespace TestEnvironment.Docker.Containers.Mongo
         public static IDockerEnvironmentBuilder AddMongoSingleReplicaSetContainer(
             this IDockerEnvironmentBuilder builder,
             string name,
+            string replicaSetName = "rs0",
             string imageName = "mongo",
             string tag = "latest",
             IDictionary<string, string> environmentVariables = null,
@@ -16,6 +17,7 @@ namespace TestEnvironment.Docker.Containers.Mongo
                 new MongoSingleReplicaSetContainer(
                     builder.DockerClient,
                     name.GetContainerName(builder.EnvironmentName),
+                    replicaSetName,
                     imageName,
                     tag,
                     environmentVariables,

--- a/src/TestEnvironment.Docker.Containers.Mongo/DockerEnvironmentBuilderExtensions.cs
+++ b/src/TestEnvironment.Docker.Containers.Mongo/DockerEnvironmentBuilderExtensions.cs
@@ -4,6 +4,28 @@ namespace TestEnvironment.Docker.Containers.Mongo
 {
     public static class DockerEnvironmentBuilderExtensions
     {
+        public static IDockerEnvironmentBuilder AddMongoSingleReplicaSetContainer(
+            this IDockerEnvironmentBuilder builder,
+            string name,
+            string imageName = "mongo",
+            string tag = "latest",
+            IDictionary<string, string> environmentVariables = null,
+            bool reuseContainer = false)
+        {
+            return builder.AddDependency(
+                new MongoSingleReplicaSetContainer(
+                    builder.DockerClient,
+                    name.GetContainerName(builder.EnvironmentName),
+                    imageName,
+                    tag,
+                    environmentVariables,
+                    builder.IsDockerInDocker,
+                    reuseContainer,
+                    new MongoSingleReplicaSetContainerWaiter(builder.Logger),
+                    new MongoContainerCleaner(builder.Logger),
+                    builder.Logger));
+        }
+
         public static IDockerEnvironmentBuilder AddMongoContainer(
             this IDockerEnvironmentBuilder builder,
             string name,

--- a/src/TestEnvironment.Docker.Containers.Mongo/IMongoContainer.cs
+++ b/src/TestEnvironment.Docker.Containers.Mongo/IMongoContainer.cs
@@ -1,0 +1,7 @@
+﻿namespace TestEnvironment.Docker.Containers.Mongo
+{
+    public interface IMongoContainer
+    {
+        string GetConnectionString();
+    }
+}

--- a/src/TestEnvironment.Docker.Containers.Mongo/MongoContainer.cs
+++ b/src/TestEnvironment.Docker.Containers.Mongo/MongoContainer.cs
@@ -6,9 +6,6 @@ namespace TestEnvironment.Docker.Containers.Mongo
 {
     public class MongoContainer : Container
     {
-        private readonly string _userName;
-        private readonly string _userPassword;
-
         public MongoContainer(
             DockerClient dockerClient,
             string name,
@@ -22,21 +19,27 @@ namespace TestEnvironment.Docker.Containers.Mongo
             bool reuseContainer = false,
             IContainerWaiter containerWaiter = null,
             IContainerCleaner containerCleaner = null,
-            ILogger logger = null)
-            : base(dockerClient, name, imageName, tag, environmentVariables, ports, isDockerInDocker, reuseContainer, containerWaiter, containerCleaner, logger)
+            ILogger logger = null,
+            IList<string> entrypoint = null,
+            IContainerInitializer containerInitializer = null)
+            : base(dockerClient, name, imageName, tag, environmentVariables, ports, isDockerInDocker, reuseContainer, containerWaiter, containerCleaner, logger, entrypoint, containerInitializer)
         {
-            _userName = userName;
-            _userPassword = userPassword;
+            UserName = userName;
+            UserPassword = userPassword;
         }
 
-        public string GetConnectionString()
+        protected string UserName { get; }
+
+        protected string UserPassword { get; }
+
+        public virtual string GetConnectionString()
         {
             var hostname = IsDockerInDocker ? IPAddress : "localhost";
             var port = IsDockerInDocker ? 27017 : Ports[27017];
 
-            return string.IsNullOrEmpty(_userName) || string.IsNullOrEmpty(_userPassword)
+            return string.IsNullOrEmpty(UserName) || string.IsNullOrEmpty(UserPassword)
                 ? $@"mongodb://{hostname}:{port}"
-                : $@"mongodb://{_userName}:{_userPassword}@{hostname}:{port}";
+                : $@"mongodb://{UserName}:{UserPassword}@{hostname}:{port}";
         }
     }
 }

--- a/src/TestEnvironment.Docker.Containers.Mongo/MongoContainer.cs
+++ b/src/TestEnvironment.Docker.Containers.Mongo/MongoContainer.cs
@@ -6,6 +6,9 @@ namespace TestEnvironment.Docker.Containers.Mongo
 {
     public class MongoContainer : Container
     {
+        private readonly string _userName;
+        private readonly string _userPassword;
+
         public MongoContainer(
             DockerClient dockerClient,
             string name,
@@ -19,27 +22,21 @@ namespace TestEnvironment.Docker.Containers.Mongo
             bool reuseContainer = false,
             IContainerWaiter containerWaiter = null,
             IContainerCleaner containerCleaner = null,
-            ILogger logger = null,
-            IList<string> entrypoint = null,
-            IContainerInitializer containerInitializer = null)
-            : base(dockerClient, name, imageName, tag, environmentVariables, ports, isDockerInDocker, reuseContainer, containerWaiter, containerCleaner, logger, entrypoint, containerInitializer)
+            ILogger logger = null)
+            : base(dockerClient, name, imageName, tag, environmentVariables, ports, isDockerInDocker, reuseContainer, containerWaiter, containerCleaner, logger)
         {
-            UserName = userName;
-            UserPassword = userPassword;
+            _userName = userName;
+            _userPassword = userPassword;
         }
 
-        protected string UserName { get; }
-
-        protected string UserPassword { get; }
-
-        public virtual string GetConnectionString()
+        public string GetConnectionString()
         {
             var hostname = IsDockerInDocker ? IPAddress : "localhost";
             var port = IsDockerInDocker ? 27017 : Ports[27017];
 
-            return string.IsNullOrEmpty(UserName) || string.IsNullOrEmpty(UserPassword)
+            return string.IsNullOrEmpty(_userName) || string.IsNullOrEmpty(_userPassword)
                 ? $@"mongodb://{hostname}:{port}"
-                : $@"mongodb://{UserName}:{UserPassword}@{hostname}:{port}";
+                : $@"mongodb://{_userName}:{_userPassword}@{hostname}:{port}";
         }
     }
 }

--- a/src/TestEnvironment.Docker.Containers.Mongo/MongoContainer.cs
+++ b/src/TestEnvironment.Docker.Containers.Mongo/MongoContainer.cs
@@ -4,7 +4,7 @@ using Microsoft.Extensions.Logging;
 
 namespace TestEnvironment.Docker.Containers.Mongo
 {
-    public class MongoContainer : Container
+    public class MongoContainer : Container, IMongoContainer
     {
         private readonly string _userName;
         private readonly string _userPassword;

--- a/src/TestEnvironment.Docker.Containers.Mongo/MongoContainerWaiter.cs
+++ b/src/TestEnvironment.Docker.Containers.Mongo/MongoContainerWaiter.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading;
+﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using MongoDB.Driver;
@@ -17,5 +18,8 @@ namespace TestEnvironment.Docker.Containers.Mongo
             await new MongoClient(container.GetConnectionString()).ListDatabasesAsync(cancellationToken);
             return true;
         }
+
+        protected override bool IsRetryable(Exception exception) =>
+            base.IsRetryable(exception) && !(exception is MongoAuthenticationException);
     }
 }

--- a/src/TestEnvironment.Docker.Containers.Mongo/MongoSingleReplicaSetContainer.cs
+++ b/src/TestEnvironment.Docker.Containers.Mongo/MongoSingleReplicaSetContainer.cs
@@ -1,0 +1,61 @@
+﻿using System.Collections.Generic;
+using Docker.DotNet;
+using Microsoft.Extensions.Logging;
+
+namespace TestEnvironment.Docker.Containers.Mongo
+{
+    public class MongoSingleReplicaSetContainer : Container
+    {
+        public MongoSingleReplicaSetContainer(
+            DockerClient dockerClient,
+            string name,
+            string imageName,
+            string tag = "latest",
+            IDictionary<string, string> environmentVariables = null,
+            bool isDockerInDocker = false,
+            bool reuseContainer = false,
+            IContainerWaiter containerWaiter = null,
+            IContainerCleaner containerCleaner = null,
+            ILogger logger = null)
+            : base(
+                dockerClient,
+                name,
+                imageName,
+                tag,
+                environmentVariables,
+                new Dictionary<ushort, ushort> { { 27017, 27017 } },
+                isDockerInDocker,
+                reuseContainer,
+                containerWaiter,
+                containerCleaner,
+                logger,
+                new List<string> { "/usr/bin/mongod", "--bind_ip_all", "--replSet", "rs0" },
+                new MongoSingleReplicaSetContainerInitializer())
+        {
+        }
+
+        public string GetDirectNodeConnectionString()
+        {
+            var hostname = IsDockerInDocker ? IPAddress : "localhost";
+            var port = IsDockerInDocker ? 27017 : Ports[27017];
+
+            return $@"mongodb://{hostname}:{port}/?connect=direct";
+
+            // return string.IsNullOrEmpty(UserName) || string.IsNullOrEmpty(UserPassword)
+            //    ? $@"mongodb://{hostname}:{port}/?connect=direct"
+            //    : $@"mongodb://{UserName}:{UserPassword}@{hostname}:{port}/?connect=direct";
+        }
+
+        public string GetConnectionString()
+        {
+            var hostname = IsDockerInDocker ? IPAddress : "localhost";
+            var port = IsDockerInDocker ? 27017 : Ports[27017];
+
+            return $@"mongodb://{hostname}:{port}/?replicaSet=rs0";
+
+            // return string.IsNullOrEmpty(UserName) || string.IsNullOrEmpty(UserPassword)
+            //     ? $@"mongodb://{hostname}:{port}/?replicaSet=rs0"
+            //     : $@"mongodb://{UserName}:{UserPassword}@{hostname}:{port}/?authSource=admin&replicaSet=rs0";
+        }
+    }
+}

--- a/src/TestEnvironment.Docker.Containers.Mongo/MongoSingleReplicaSetContainer.cs
+++ b/src/TestEnvironment.Docker.Containers.Mongo/MongoSingleReplicaSetContainer.cs
@@ -1,14 +1,16 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Docker.DotNet;
 using Microsoft.Extensions.Logging;
 
 namespace TestEnvironment.Docker.Containers.Mongo
 {
-    public class MongoSingleReplicaSetContainer : Container
+    public class MongoSingleReplicaSetContainer : Container, IMongoContainer
     {
         public MongoSingleReplicaSetContainer(
             DockerClient dockerClient,
             string name,
+            string replicaSetName,
             string imageName,
             string tag = "latest",
             IDictionary<string, string> environmentVariables = null,
@@ -29,9 +31,13 @@ namespace TestEnvironment.Docker.Containers.Mongo
                 containerWaiter,
                 containerCleaner,
                 logger,
-                new List<string> { "/usr/bin/mongod", "--bind_ip_all", "--replSet", "rs0" },
-                new MongoSingleReplicaSetContainerInitializer())
+                new List<string> { "/usr/bin/mongod", "--bind_ip_all", "--replSet", replicaSetName },
+                new MongoSingleReplicaSetContainerInitializer(replicaSetName))
         {
+            if (string.IsNullOrWhiteSpace(replicaSetName))
+            {
+                throw new ArgumentException("The value must be specified", nameof(replicaSetName));
+            }
         }
 
         public string GetDirectNodeConnectionString()

--- a/src/TestEnvironment.Docker.Containers.Mongo/MongoSingleReplicaSetContainer.cs
+++ b/src/TestEnvironment.Docker.Containers.Mongo/MongoSingleReplicaSetContainer.cs
@@ -1,18 +1,23 @@
 ﻿using System;
 using System.Collections.Generic;
 using Docker.DotNet;
+using Docker.DotNet.Models;
 using Microsoft.Extensions.Logging;
 
 namespace TestEnvironment.Docker.Containers.Mongo
 {
     public class MongoSingleReplicaSetContainer : Container, IMongoContainer
     {
+        private readonly string _replicaSetName;
+        private readonly ushort? _port;
+
         public MongoSingleReplicaSetContainer(
             DockerClient dockerClient,
             string name,
             string replicaSetName,
             string imageName,
             string tag = "latest",
+            ushort? port = null,
             IDictionary<string, string> environmentVariables = null,
             bool isDockerInDocker = false,
             bool reuseContainer = false,
@@ -25,25 +30,28 @@ namespace TestEnvironment.Docker.Containers.Mongo
                 imageName,
                 tag,
                 environmentVariables,
-                new Dictionary<ushort, ushort> { { 27017, 27017 } },
+                port == null ? new Dictionary<ushort, ushort> { { 27017, 27017 } } : new Dictionary<ushort, ushort> { { port.Value, port.Value } },
                 isDockerInDocker,
                 reuseContainer,
                 containerWaiter,
                 containerCleaner,
                 logger,
-                new List<string> { "/usr/bin/mongod", "--bind_ip_all", "--replSet", replicaSetName },
+                port == null ? new List<string> { "/usr/bin/mongod", "--bind_ip_all", "--replSet", replicaSetName } : new List<string> { "/usr/bin/mongod", "--bind_ip_all", "--replSet", replicaSetName, "--port", port.Value.ToString() },
                 new MongoSingleReplicaSetContainerInitializer(replicaSetName))
         {
             if (string.IsNullOrWhiteSpace(replicaSetName))
             {
                 throw new ArgumentException("The value must be specified", nameof(replicaSetName));
             }
+
+            _replicaSetName = replicaSetName;
+            _port = port;
         }
 
         public string GetDirectNodeConnectionString()
         {
             var hostname = IsDockerInDocker ? IPAddress : "localhost";
-            var port = IsDockerInDocker ? 27017 : Ports[27017];
+            var port = _port ?? (IsDockerInDocker ? 27017 : Ports[27017]);
 
             return $@"mongodb://{hostname}:{port}/?connect=direct";
         }
@@ -51,9 +59,22 @@ namespace TestEnvironment.Docker.Containers.Mongo
         public string GetConnectionString()
         {
             var hostname = IsDockerInDocker ? IPAddress : "localhost";
-            var port = IsDockerInDocker ? 27017 : Ports[27017];
+            var port = _port ?? (IsDockerInDocker ? 27017 : Ports[27017]);
 
-            return $@"mongodb://{hostname}:{port}/?replicaSet=rs0";
+            return $@"mongodb://{hostname}:{port}/?replicaSet={_replicaSetName}";
+        }
+
+        protected override CreateContainerParameters GetCreateContainerParameters(string[] environmentVariables)
+        {
+            var createParams = base.GetCreateContainerParameters(environmentVariables);
+
+            if (_port != null)
+            {
+                // custom mongo port isn't exposed by default from docker container
+                createParams.ExposedPorts = new Dictionary<string, EmptyStruct> { { $"{_port.Value}/tcp", default } };
+            }
+
+            return createParams;
         }
     }
 }

--- a/src/TestEnvironment.Docker.Containers.Mongo/MongoSingleReplicaSetContainer.cs
+++ b/src/TestEnvironment.Docker.Containers.Mongo/MongoSingleReplicaSetContainer.cs
@@ -40,10 +40,6 @@ namespace TestEnvironment.Docker.Containers.Mongo
             var port = IsDockerInDocker ? 27017 : Ports[27017];
 
             return $@"mongodb://{hostname}:{port}/?connect=direct";
-
-            // return string.IsNullOrEmpty(UserName) || string.IsNullOrEmpty(UserPassword)
-            //    ? $@"mongodb://{hostname}:{port}/?connect=direct"
-            //    : $@"mongodb://{UserName}:{UserPassword}@{hostname}:{port}/?connect=direct";
         }
 
         public string GetConnectionString()
@@ -52,10 +48,6 @@ namespace TestEnvironment.Docker.Containers.Mongo
             var port = IsDockerInDocker ? 27017 : Ports[27017];
 
             return $@"mongodb://{hostname}:{port}/?replicaSet=rs0";
-
-            // return string.IsNullOrEmpty(UserName) || string.IsNullOrEmpty(UserPassword)
-            //     ? $@"mongodb://{hostname}:{port}/?replicaSet=rs0"
-            //     : $@"mongodb://{UserName}:{UserPassword}@{hostname}:{port}/?authSource=admin&replicaSet=rs0";
         }
     }
 }

--- a/src/TestEnvironment.Docker.Containers.Mongo/MongoSingleReplicaSetContainerInitializer.cs
+++ b/src/TestEnvironment.Docker.Containers.Mongo/MongoSingleReplicaSetContainerInitializer.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using MongoDB.Bson;
+using MongoDB.Driver;
+
+namespace TestEnvironment.Docker.Containers.Mongo
+{
+    public class MongoSingleReplicaSetContainerInitializer : IContainerInitializer<MongoSingleReplicaSetContainer>
+    {
+        public async Task<bool> Initialize(
+            MongoSingleReplicaSetContainer container,
+            CancellationToken cancellationToken)
+        {
+            if (container == null)
+            {
+                throw new ArgumentNullException(nameof(container));
+            }
+
+            var mongoClient = new MongoClient(container.GetDirectNodeConnectionString());
+
+            await mongoClient.GetDatabase("admin").RunCommandAsync(
+                new BsonDocumentCommand<BsonDocument>(new BsonDocument
+                {
+                    {
+                        "replSetInitiate",
+                        new BsonDocument
+                        {
+                            { "_id", "rs0" },
+                            {
+                                "members",
+                                new BsonArray
+                                {
+                                    new BsonDocument
+                                    {
+                                        { "_id", 0 },
+                                        {
+                                            "host",
+                                            mongoClient.Settings.Server.ToString()
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }), cancellationToken: cancellationToken);
+
+            return true;
+        }
+
+        public Task<bool> Initialize(Container container, CancellationToken cancellationToken) =>
+            Initialize(container as MongoSingleReplicaSetContainer, cancellationToken);
+    }
+}

--- a/src/TestEnvironment.Docker.Containers.Mongo/MongoSingleReplicaSetContainerWaiter.cs
+++ b/src/TestEnvironment.Docker.Containers.Mongo/MongoSingleReplicaSetContainerWaiter.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using MongoDB.Bson;
+using MongoDB.Driver;
+
+namespace TestEnvironment.Docker.Containers.Mongo
+{
+    public class MongoSingleReplicaSetContainerWaiter : BaseContainerWaiter<MongoSingleReplicaSetContainer>
+    {
+        public MongoSingleReplicaSetContainerWaiter(ILogger logger)
+            : base(logger)
+        {
+        }
+
+        protected override async Task<bool> PerformCheck(
+            MongoSingleReplicaSetContainer container,
+            CancellationToken cancellationToken)
+        {
+            await new MongoClient(container.GetDirectNodeConnectionString()).GetDatabase("admin")
+                .RunCommandAsync(
+                    new BsonDocumentCommand<BsonDocument>(new BsonDocument("ping", 1)),
+                    cancellationToken: cancellationToken);
+            return true;
+        }
+
+        protected override bool IsRetryable(Exception exception) =>
+            base.IsRetryable(exception) && !(exception is MongoAuthenticationException);
+    }
+}

--- a/src/TestEnvironment.Docker/BaseContainerWaiter.cs
+++ b/src/TestEnvironment.Docker/BaseContainerWaiter.cs
@@ -50,7 +50,7 @@ namespace TestEnvironment.Docker
             }
             while (attempts != 0);
 
-            Logger.LogError($"Container {container.Name} didn't start.");
+            Logger?.LogError($"Container {container.Name} didn't start.");
             return false;
         }
 

--- a/src/TestEnvironment.Docker/Container.cs
+++ b/src/TestEnvironment.Docker/Container.cs
@@ -58,7 +58,7 @@ namespace TestEnvironment.Docker
 
         public IDictionary<ushort, ushort> Ports { get; private set; }
 
-        public IList<string> Entrypoint { get; private set; }
+        public IList<string> Entrypoint { get; }
 
         public string ImageName { get; }
 

--- a/src/TestEnvironment.Docker/IContainerInitializer.cs
+++ b/src/TestEnvironment.Docker/IContainerInitializer.cs
@@ -1,0 +1,15 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+
+namespace TestEnvironment.Docker
+{
+    public interface IContainerInitializer
+    {
+        Task<bool> Initialize(Container container, CancellationToken cancellationToken);
+    }
+
+    public interface IContainerInitializer<in TContainer> : IContainerInitializer
+    {
+        Task<bool> Initialize(TContainer container, CancellationToken cancellationToken);
+    }
+}

--- a/test/TestEnvironment.Docker.Tests/DockerEnvironmentTests.cs
+++ b/test/TestEnvironment.Docker.Tests/DockerEnvironmentTests.cs
@@ -6,6 +6,7 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using FluentFTP;
 using MailKit.Net.Smtp;
+using Microsoft.Extensions.Logging;
 using MongoDB.Bson;
 using MongoDB.Driver;
 using MySql.Data.MySqlClient;
@@ -26,10 +27,12 @@ namespace TestEnvironment.Docker.Tests
     public class DockerEnvironmentTests
     {
         private readonly ITestOutputHelper _testOutput;
+        private readonly ILogger _logger;
 
         public DockerEnvironmentTests(ITestOutputHelper testOutput)
         {
             _testOutput = testOutput;
+            _logger = new XUnitLogger(testOutput);
         }
 
         [Fact]
@@ -111,6 +114,7 @@ namespace TestEnvironment.Docker.Tests
             var environment = new DockerEnvironmentBuilder()
                 .UseDefaultNetwork()
                 .SetName("test-env")
+                .WithLogger(_logger)
 #if DEBUG
                 .AddMongoContainer("my-mongo", reuseContainer: true)
 #else

--- a/test/TestEnvironment.Docker.Tests/XUnitLogger.cs
+++ b/test/TestEnvironment.Docker.Tests/XUnitLogger.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using Microsoft.Extensions.Logging;
+using Xunit.Abstractions;
+
+namespace TestEnvironment.Docker.Tests
+{
+    public class XUnitLogger : ILogger
+    {
+        private readonly ITestOutputHelper _testOutputHelper;
+
+        public XUnitLogger(ITestOutputHelper testOutputHelper)
+        {
+            _testOutputHelper = testOutputHelper;
+        }
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception exception,
+            Func<TState, Exception, string> formatter)
+        {
+            var message = formatter(state, exception);
+
+            _testOutputHelper.WriteLine($"{logLevel.ToString()}: {message}");
+        }
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public IDisposable BeginScope<TState>(TState state)
+        {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
## The goal of changes

Not often, but in some cases, it's needed to bootstrap MongoDB for test purposes in replica set mode. One of the features is [change streams](https://docs.mongodb.com/manual/changeStreams/).
In addition, to bootstrap MongoDB replica set isn't an easy task and some preparation to use such instance is needed.
1. Firstly, Mongo DB should be run in replica set mode. It can be achieved with entry point customization ` "/usr/bin/mongod", "--bind_ip_all", "--replSet", "rs0"`. **By this reason I've added opportunity to specify entrypoint**
2. The second challenge is in the process of establishing connection with the replica set. More details about such a process can be found at [MongoDB documentation](https://docs.mongodb.com/manual/core/read-preference-mechanics/). In our case, Mongo DB returns host and ports which is defined inside a docker container. E.g., we define `32017:27017` port mapping. It means that Mongo DB will be available for use with the `32017` port, which works perfectly in `standalone` mode due to no need in the server selection mechanism. In case of replica set mode, where selection mechanism is involved, MongoDB established a connection with the client, but after the server, the selection will return `27017` port instead of `32017` due to such value is placed in replica set configuration. After that client will be disconnected by timeout. **This is the exact reason why static hardcoded `27017:27017` port mappings are used.**
3. The last thing which is also important is the replica set configuration. To configure Mongo DB programmatically, driver should connect to the node directly. A connection string for direct connect to node is defined in `GetDirectNodeConnectionString`. After direct connection, replica set must be initialized with [`replSetInitiate` command](https://docs.mongodb.com/manual/reference/command/replSetInitiate/). The logic for replica set initialization is addressed in `MongoSingleReplicaSetContainerInitializer`.

In addition, the auth mechanism via environment variables doesn't work. More details can be found at https://github.com/docker-library/mongo/issues/339

P.S.: should be merged after #33 