### PR TITLE
bumped version of concrete packages to avoid binaries incompatibilities

### DIFF
--- a/src/TestEnvironment.Docker.Containers.Elasticsearch/TestEnvironment.Docker.Containers.Elasticsearch.csproj
+++ b/src/TestEnvironment.Docker.Containers.Elasticsearch/TestEnvironment.Docker.Containers.Elasticsearch.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>TestEnvironment.Docker.Containers.Elasticsearch</AssemblyName>
     <RootNamespace>TestEnvironment.Docker.Containers.Elasticsearch</RootNamespace>
-    <Version>1.1.6</Version>
+    <Version>1.1.7</Version>
     <PackageId>TestEnvironment.Docker.Containers.Elasticsearch</PackageId>
     <Authors>Aliaksei Harshkalep</Authors>
     <Description>Add Elasticsearch container specific functionality.</Description>

--- a/src/TestEnvironment.Docker.Containers.Ftp/TestEnvironment.Docker.Containers.Ftp.csproj
+++ b/src/TestEnvironment.Docker.Containers.Ftp/TestEnvironment.Docker.Containers.Ftp.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>TestEnvironment.Docker.Containers.Ftp</AssemblyName>
     <RootNamespace>TestEnvironment.Docker.Containers.Ftp</RootNamespace>
-    <Version>1.0.4</Version>
+    <Version>1.0.5</Version>
     <PackageId>TestEnvironment.Docker.Containers.Ftp</PackageId>
     <Authors>Aliaksei Harshkalep</Authors>
     <Description>Add FTP container specific functionality.</Description>

--- a/src/TestEnvironment.Docker.Containers.Mail/TestEnvironment.Docker.Containers.Mail.csproj
+++ b/src/TestEnvironment.Docker.Containers.Mail/TestEnvironment.Docker.Containers.Mail.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>TestEnvironment.Docker.Containers.Mail</AssemblyName>
     <RootNamespace>TestEnvironment.Docker.Containers.Mail</RootNamespace>
-    <Version>1.0.4</Version>
+    <Version>1.0.5</Version>
     <PackageId>TestEnvironment.Docker.Containers.Mail</PackageId>
     <Authors>Aliaksei Harshkalep</Authors>
     <Description>Add SMTP container specific functionality.</Description>

--- a/src/TestEnvironment.Docker.Containers.MariaDB/TestEnvironment.Docker.Containers.MariaDB.csproj
+++ b/src/TestEnvironment.Docker.Containers.MariaDB/TestEnvironment.Docker.Containers.MariaDB.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>TestEnvironment.Docker.Containers.MariaDB</AssemblyName>
     <RootNamespace>TestEnvironment.Docker.Containers.MariaDB</RootNamespace>
-    <Version>1.0.6</Version>
+    <Version>1.0.7</Version>
     <PackageId>TestEnvironment.Docker.Containers.MariaDB</PackageId>
     <Authors>Aliaksei Harshkalep</Authors>
     <Description>Add MariaDB container specific functionality.</Description>

--- a/src/TestEnvironment.Docker.Containers.Mssql/TestEnvironment.Docker.Containers.Mssql.csproj
+++ b/src/TestEnvironment.Docker.Containers.Mssql/TestEnvironment.Docker.Containers.Mssql.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>TestEnvironment.Docker.Containers.Mssql</AssemblyName>
     <RootNamespace>TestEnvironment.Docker.Containers.Mssql</RootNamespace>
-    <Version>1.0.6</Version>
+    <Version>1.0.7</Version>
     <PackageId>TestEnvironment.Docker.Containers.Mssql</PackageId>
     <Authors>Aliaksei Harshkalep</Authors>
     <Description>Add MSSQL container specific functionality.</Description>

--- a/src/TestEnvironment.Docker.Containers.Postgres/TestEnvironment.Docker.Containers.Postgres.csproj
+++ b/src/TestEnvironment.Docker.Containers.Postgres/TestEnvironment.Docker.Containers.Postgres.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>TestEnvironment.Docker.Containers.Postgres</AssemblyName>
     <RootNamespace>TestEnvironment.Docker.Containers.Postgres</RootNamespace>
-    <Version>1.0.5</Version>
+    <Version>1.0.6</Version>
     <PackageId>TestEnvironment.Docker.Containers.Postgres</PackageId>
     <Authors>Kiryl Kiryanchykau</Authors>
     <Description>Add Postgres container specific functionality.</Description>


### PR DESCRIPTION
Resolves #37
Between two versions of the main library, some changes in public contracts were introduced. They appear to be backward incompatible with previous versions of dependent packages (Mssql, FTP, etc.). The easiest way to solve this is to release a new version of each package.
This problem might appear in the future. Each change in public contracts will cause an issue in all dependent on the core project packages. I'd recommend considering writing a script that increments the version of each child package whenever we have changed something in the core _TestEnvironment.Docker_ project