### PR TITLE
downgrade MongoDB.Driver version to 2.4.0

### DIFF
--- a/src/TestEnvironment.Docker.Containers.Mongo/MongoContainerCleaner.cs
+++ b/src/TestEnvironment.Docker.Containers.Mongo/MongoContainerCleaner.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -33,7 +34,10 @@ namespace TestEnvironment.Docker.Containers.Mongo
             }
 
             var client = new MongoClient(container.GetConnectionString());
-            var databaseNames = (await client.ListDatabaseNamesAsync(cancellationToken)).ToList();
+            var databaseNames = (await client.ListDatabasesAsync(cancellationToken))
+                .ToList()
+                .Select(x => x["name"].AsString);
+
             try
             {
                 foreach (var databaseName in databaseNames)

--- a/src/TestEnvironment.Docker.Containers.Mongo/MongoSingleReplicaSetContainerInitializer.cs
+++ b/src/TestEnvironment.Docker.Containers.Mongo/MongoSingleReplicaSetContainerInitializer.cs
@@ -83,7 +83,7 @@ namespace TestEnvironment.Docker.Containers.Mongo
                        configuration["config"]["members"].AsBsonArray[0]["host"] ==
                        mongoClient.Settings.Server.ToString();
             }
-            catch (MongoCommandException exception) when (exception.CodeName == "NotYetInitialized")
+            catch (MongoCommandException exception) when (exception.Code == 94 /*"NotYetInitialized"*/)
             {
                 return false;
             }

--- a/src/TestEnvironment.Docker.Containers.Mongo/TestEnvironment.Docker.Containers.Mongo.csproj
+++ b/src/TestEnvironment.Docker.Containers.Mongo/TestEnvironment.Docker.Containers.Mongo.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MongoDB.Driver" Version="2.8.0" />
+    <PackageReference Include="MongoDB.Driver" Version="2.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/TestEnvironment.Docker.Containers.Mongo/TestEnvironment.Docker.Containers.Mongo.csproj
+++ b/src/TestEnvironment.Docker.Containers.Mongo/TestEnvironment.Docker.Containers.Mongo.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>TestEnvironment.Docker.Containers.Mongo</AssemblyName>
     <RootNamespace>TestEnvironment.Docker.Containers.Mongo</RootNamespace>
-    <Version>1.1.7</Version>
+    <Version>1.2.0</Version>
     <PackageId>TestEnvironment.Docker.Containers.Mongo</PackageId>
     <Authors>Uladzimir Lashkevich, Aliaksei Harshkalep, vhatsura</Authors>
     <Description>Add MongoDB container specific functionality.</Description>


### PR DESCRIPTION
The lowest referenced library as a dependency, the more use cases where the final library can be used. For this reason, the PR targets to downgrade of `MongoDB.Driver` to `2.4.0`. Luckily, the Mongo team doesn't break the backward compatibility of the public API every release, which allows targeting the lowest version. E.g., NEST has broken public APIs between minor versions (#27 as an example).

I know that introducing such a statement means that all libraries need to be revised, but for me, at least for now, MongoDB is more crucial. 