### PR TITLE
Use 'Filters' parameter in place of 'Filter' -> removed from docker API Image List Query Parameters

### DIFF
--- a/src/TestEnvironment.Docker/DockerEnvironment.cs
+++ b/src/TestEnvironment.Docker/DockerEnvironment.cs
@@ -209,19 +209,20 @@ namespace TestEnvironment.Docker
 
         private async Task PullRequiredImages(CancellationToken token)
         {
-            foreach (var contianer in Dependencies.OfType<Container>())
+            foreach (var container in Dependencies.OfType<Container>())
             {
                 var images = await _dockerClient.Images.ListImagesAsync(
                     new ImagesListParameters
                     {
                         All = true,
-                        MatchName = $"{contianer.ImageName}:{contianer.Tag}"
+                        Filters = new Dictionary<string, IDictionary<string, bool>>
+                        { ["reference"] = new Dictionary<string, bool> { [$"{container.ImageName}:{container.Tag}"] = true } }
                     },
                     token);
 
                 if (!images.Any())
                 {
-                    _logger.LogInformation($"Pulling the image {contianer.ImageName}:{contianer.Tag}");
+                    _logger.LogInformation($"Pulling the image {container.ImageName}:{container.Tag}");
 
                     // Pull the image.
                     try
@@ -229,16 +230,16 @@ namespace TestEnvironment.Docker
                         await _dockerClient.Images.CreateImageAsync(
                             new ImagesCreateParameters
                             {
-                                FromImage = contianer.ImageName,
-                                Tag = contianer.Tag
+                                FromImage = container.ImageName,
+                                Tag = container.Tag
                             },
                             null,
-                            new Progress<JSONMessage>(m => _logger.LogDebug($"Pulling image {contianer.ImageName}:{contianer.Tag}:\n{m.ProgressMessage}")),
+                            new Progress<JSONMessage>(m => _logger.LogDebug($"Pulling image {container.ImageName}:{container.Tag}:\n{m.ProgressMessage}")),
                             token);
                     }
                     catch (Exception exc)
                     {
-                        _logger?.LogError(exc, $"Unable to pull the image {contianer.ImageName}:{contianer.Tag}");
+                        _logger?.LogError(exc, $"Unable to pull the image {container.ImageName}:{container.Tag}");
                         throw;
                     }
                 }


### PR DESCRIPTION
Update docker API call to remove discarded 'Filter' parameter when querying images.  Replaced by 'Filters' 

Docker.DotNet library doesn't reflect this change on docker API and image pulling was failing.
https://docs.docker.com/engine/api/v1.41/#operation/ImageList