### PR TITLE
Switch from deprecated SQL Server container image

### DIFF
--- a/src/TestEnvironment.Docker.Containers.Mssql/DockerEnvironmentBuilderExtensions.cs
+++ b/src/TestEnvironment.Docker.Containers.Mssql/DockerEnvironmentBuilderExtensions.cs
@@ -4,7 +4,7 @@ namespace TestEnvironment.Docker.Containers.Mssql
 {
     public static class DockerEnvironmentBuilderExtensions
     {
-        public static IDockerEnvironmentBuilder AddMssqlContainer(this IDockerEnvironmentBuilder builder, string name, string saPassword, string imageName = "microsoft/mssql-server-linux", string tag = "latest", IDictionary<string, string> environmentVariables = null, IDictionary<ushort, ushort> ports = null, bool reuseContainer = false) =>
+        public static IDockerEnvironmentBuilder AddMssqlContainer(this IDockerEnvironmentBuilder builder, string name, string saPassword, string imageName = "mcr.microsoft.com/mssql/server", string tag = "latest", IDictionary<string, string> environmentVariables = null, IDictionary<ushort, ushort> ports = null, bool reuseContainer = false) =>
             builder.AddDependency(new MssqlContainer(builder.DockerClient, name.GetContainerName(builder.EnvironmentName), saPassword, imageName, tag, environmentVariables, ports, builder.IsDockerInDocker, reuseContainer, builder.Logger));
     }
 }


### PR DESCRIPTION
Noticed that container image for SQL Server [`microsoft/mssql-server-linux`](https://hub.docker.com/r/microsoft/mssql-server-linux) was marked as deprecated. I went ahead and updated defaults to [`mcr.microsoft.com/mssql/server`](https://hub.docker.com/_/microsoft-mssql-server).

As of today image at `mcr.microsoft.com/mssql/server:latest` is SQL Server 2019, so this could potentially be a breaking change for someone who relies on SQL Server 2017.