### PR TITLE
Bump SharpCompress from 0.24.0 to 0.29.0 in /src/TestEnvironment.Dock…

### DIFF
--- a/src/TestEnvironment.Docker/TestEnvironment.Docker.csproj
+++ b/src/TestEnvironment.Docker/TestEnvironment.Docker.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="1.1.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.1.0" />
-    <PackageReference Include="SharpCompress" Version="0.24.0" />
+    <PackageReference Include="SharpCompress" Version="0.29.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
…er (#56)

Bumps [SharpCompress](https://github.com/adamhathcock/sharpcompress) from 0.24.0 to 0.29.0.
- [Release notes](https://github.com/adamhathcock/sharpcompress/releases)
- [Commits](https://github.com/adamhathcock/sharpcompress/compare/0.24...0.29)

---
updated-dependencies:
- dependency-name: SharpCompress
  dependency-type: direct:production
...

Signed-off-by: dependabot[bot] <support@github.com>

Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>