### PR TITLE
feat: remove MSSQL_PID env var from Mssql

### DIFF
--- a/src/TestEnvironment.Docker.Containers.Mssql/IDockerEnvironmentBuilderExtensions.cs
+++ b/src/TestEnvironment.Docker.Containers.Mssql/IDockerEnvironmentBuilderExtensions.cs
@@ -65,8 +65,7 @@ namespace TestEnvironment.Docker.Containers.Mssql
                 EnvironmentVariables = new Dictionary<string, string>
                 {
                     ["ACCEPT_EULA"] = "Y",
-                    ["SA_PASSWORD"] = p.SAPassword,
-                    ["MSSQL_PID"] = "Express"
+                    ["SA_PASSWORD"] = p.SAPassword
                 }.MergeDictionaries(p.EnvironmentVariables),
             };
 


### PR DESCRIPTION
Removing MSSQL_PID from Mssql container will enable to use AzureSqlEdge image. It's not possible because predefined MSSQL_PID=Express is not supported by AzureSqlEdge and container fail to start.

SqlServer allows these MSSQL_PID:
- Evaluation
- Developer
- Express
- Web
- Standard
- Enterprise
- A product key in format #####-#####-#####-#####-#####, where '#' is a number or a letter

AzureSqlEdge allows these MSSQL_PID:
- Developer
- Enterprise

Let's get start container with default MSSQL_PID.